### PR TITLE
cmake in conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Archived code base corresponding to publication: https://zenodo.org/record/74199
     - The Community variant is sufficient and is free for everyone.
     - During the installation, select the *workload Desktop Development with C++*.
     - The code was tested with the 2017, 2019, and 2022 Community editions.
-3. **Linux only**: Install OpenBLAS libraries.
+3. **Linux only**: Install OpenBLAS libraries
     - `sudo apt-get install libopenblas-base`
 
     

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Archived code base corresponding to publication: https://zenodo.org/record/74199
     - The Community variant is sufficient and is free for everyone.
     - During the installation, select the *workload Desktop Development with C++*.
     - The code was tested with the 2017, 2019, and 2022 Community editions.
-3. **Linux only**: Install OpenBLAS libraries
+2. **Linux only**: Install OpenBLAS libraries
     - `sudo apt-get install libopenblas-base`
 
     

--- a/README.md
+++ b/README.md
@@ -27,17 +27,17 @@ Archived code base corresponding to publication: https://zenodo.org/record/74199
     - Clone the repository: `git clone https://github.com/stanfordnmbl/opencap-processing.git`
     - Navigate to the directory: `cd opencap-processing`
 7. Install required packages: `python -m pip install -r requirements.txt`
-    
+8. Run `python createAuthenticationEnvFile.py`
+    - An environment variable (`.env` file) will be saved after authenticating.    
     
 ### Muscle-driven simulations
-1. Install [CMake](https://cmake.org/download/)
-    - **Windows only**: Add CMake to system path. During the installation, select *Add CMake to the system PATH for all users*
-2. **Windows only**: Install [Visual Studio](https://visualstudio.microsoft.com/downloads/)
+1. **Windows only**: Install [Visual Studio](https://visualstudio.microsoft.com/downloads/)
     - The Community variant is sufficient and is free for everyone.
     - During the installation, select the *workload Desktop Development with C++*.
     - The code was tested with the 2017, 2019, and 2022 Community editions.
-3. Run `createAuthenticationEnvFile.py`
-    - An environment variable (`.env` file) will be saved after authenticating.
+3. **Linux only**: Install OpenBLAS libraries.
+    - `sudo apt-get install libopenblas-base`
+
     
 ## Examples
 - Run `example.py` for examples of how to run kinematic analyses
@@ -53,6 +53,4 @@ Archived code base corresponding to publication: https://zenodo.org/record/74199
 
 ### Locally
 - Follow the install requirements above
-- (Optional): Run `createAuthenticationEnvFile.py`
-    - An environment variable (`.env` file) will be saved after authenticating. You can proceed without this, but you will be required to login every time you run a script.
 - Open `batchDownload.py` and follow the instructions

--- a/UtilsDynamicSimulations/OpenSimAD/utilsOpenSimAD.py
+++ b/UtilsDynamicSimulations/OpenSimAD/utilsOpenSimAD.py
@@ -1592,7 +1592,7 @@ def buildExternalFunction(filename, pathDCAD, CPP_DIR, nInputs,
             cmd_tar = 'tar -xf linux.tar.gz -C "{}"'.format(OpenSimAD_DIR)
             os.system(cmd_tar)
             os.remove('linux.tar.gz')
-        cmd1 = 'cmake "' + pathBuildExpressionGraph + '" -DTARGET_NAME:STRING="' + filename + '" -DSDK_DIR:PATH="' + OpenSimADOS_DIR + '" -DCPP_DIR:PATH="' + CPP_DIR + '" -DCMAKE_INSTALL_PREFIX= "' + OpenSimADOS_DIR + '"'
+        cmd1 = 'cmake "' + pathBuildExpressionGraph + '" -DTARGET_NAME:STRING="' + filename + '" -DSDK_DIR:PATH="' + OpenSimADOS_DIR + '" -DCPP_DIR:PATH="' + CPP_DIR + '"'
         cmd2 = "make"
         BIN_DIR = pathBuild
         

--- a/UtilsDynamicSimulations/OpenSimAD/utilsOpenSimAD.py
+++ b/UtilsDynamicSimulations/OpenSimAD/utilsOpenSimAD.py
@@ -1606,7 +1606,7 @@ def buildExternalFunction(filename, pathDCAD, CPP_DIR, nInputs,
             cmd_tar = 'tar -xf macOS.tgz -C "{}"'.format(OpenSimAD_DIR)
             os.system(cmd_tar)
             os.remove('macOS.tgz')
-        cmd1 = 'cmake "' + pathBuildExpressionGraph + '" -DTARGET_NAME:STRING="' + filename + '" -DSDK_DIR:PATH="' + OpenSimADOS_DIR + '" -DCPP_DIR:PATH="' + CPP_DIR + '" -DCMAKE_INSTALL_PREFIX= "' + OpenSimADOS_DIR + '"'
+        cmd1 = 'cmake "' + pathBuildExpressionGraph + '" -DTARGET_NAME:STRING="' + filename + '" -DSDK_DIR:PATH="' + OpenSimADOS_DIR + '" -DCPP_DIR:PATH="' + CPP_DIR + '"'
         cmd2 = "make"
         BIN_DIR = pathBuild
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ requests
 casadi
 pyyaml
 joblib
+cmake


### PR DESCRIPTION
There is a cmake conda package and it automatically adds cmake to the path. Only one added line in the requirements, but quite an impact for users who do not need to install cmake anymore (a few forum posts already about cmake issues).

Very minor changes required in the code, just changed a few things in the readme. I figured that on linux, you need to install some libraries, so that's been added to the readme too (I had these libraries installed already on my machine).

Tests I've done:
- I removed CMake from the machine on Windows, Mac, and Linux and could run example_kinetics.py without problems.

BTW I added creating the env file to the general instructions to avoid problems down the line. People trying to run exmaple_kinetics but having issues to authenticate.