### PR TITLE
[WIP] adjust bounds (polynomials and variables) based on motion if out of default

### DIFF
--- a/UtilsDynamicSimulations/OpenSimAD/boundsOpenSimAD.py
+++ b/UtilsDynamicSimulations/OpenSimAD/boundsOpenSimAD.py
@@ -42,45 +42,16 @@ class bounds_tracking:
             splineD2 = spline.derivative(n=2)
             self.Qdotdots_spline[joint] = splineD2(self.Qs['time'])
     
-    def getBoundsPosition(self):
+    def getBoundsPosition(self, polynomial_bounds):
         
         self.splineQs()        
         upperBoundsPosition_all = {}
-        lowerBoundsPosition_all = {}      
-        upperBoundsPosition_all['hip_flexion_l'] = [120 * np.pi / 180]
-        upperBoundsPosition_all['hip_flexion_r'] = [120 * np.pi / 180]
-        upperBoundsPosition_all['hip_adduction_l'] = [20 * np.pi / 180]
-        upperBoundsPosition_all['hip_adduction_r'] = [20 * np.pi / 180]
-        upperBoundsPosition_all['hip_rotation_l'] = [35 * np.pi / 180]
-        upperBoundsPosition_all['hip_rotation_r'] = [35 * np.pi / 180]  
-        upperBoundsPosition_all['knee_angle_l'] = [138 * np.pi / 180]
-        upperBoundsPosition_all['knee_angle_r'] = [138 * np.pi / 180]
-        upperBoundsPosition_all['knee_adduction_l'] = [20 * np.pi / 180]
-        upperBoundsPosition_all['knee_adduction_r'] = [20 * np.pi / 180]
-        upperBoundsPosition_all['ankle_angle_l'] = [50 * np.pi / 180]
-        upperBoundsPosition_all['ankle_angle_r'] = [50 * np.pi / 180]
-        upperBoundsPosition_all['subtalar_angle_l'] = [35 * np.pi / 180] 
-        upperBoundsPosition_all['subtalar_angle_r'] = [35 * np.pi / 180] 
-        upperBoundsPosition_all['mtp_angle_l'] = [5 * np.pi / 180]
-        upperBoundsPosition_all['mtp_angle_r'] = [5 * np.pi / 180]        
-      
-        lowerBoundsPosition_all['hip_flexion_l'] = [-30 * np.pi / 180]
-        lowerBoundsPosition_all['hip_flexion_r'] = [-30 * np.pi / 180]
-        lowerBoundsPosition_all['hip_adduction_l'] = [-50 * np.pi / 180]
-        lowerBoundsPosition_all['hip_adduction_r'] = [-50 * np.pi / 180]
-        lowerBoundsPosition_all['hip_rotation_l'] = [-40 * np.pi / 180]
-        lowerBoundsPosition_all['hip_rotation_r'] = [-40 * np.pi / 180]       
-        lowerBoundsPosition_all['knee_angle_l'] = [0 * np.pi / 180]
-        lowerBoundsPosition_all['knee_angle_r'] = [0 * np.pi / 180]        
-        lowerBoundsPosition_all['knee_adduction_l'] = [-30 * np.pi / 180]
-        lowerBoundsPosition_all['knee_adduction_r'] = [-30 * np.pi / 180]        
-        lowerBoundsPosition_all['ankle_angle_l'] = [-50 * np.pi / 180]
-        lowerBoundsPosition_all['ankle_angle_r'] = [-50 * np.pi / 180]        
-        lowerBoundsPosition_all['subtalar_angle_l'] = [-35 * np.pi / 180] 
-        lowerBoundsPosition_all['subtalar_angle_r'] = [-35 * np.pi / 180]        
-        lowerBoundsPosition_all['mtp_angle_l'] = [-45 * np.pi / 180]
-        lowerBoundsPosition_all['mtp_angle_r'] = [-45 * np.pi / 180]        
-        
+        lowerBoundsPosition_all = {}
+        for coord in polynomial_bounds:
+            upperBoundsPosition_all[coord] = (
+                [polynomial_bounds[coord]['max'] * np.pi / 180])
+            lowerBoundsPosition_all[coord] = (
+                [polynomial_bounds[coord]['min'] * np.pi / 180])
         upperBoundsPosition = pd.DataFrame()   
         lowerBoundsPosition = pd.DataFrame() 
         scalingPosition = pd.DataFrame() 

--- a/UtilsDynamicSimulations/OpenSimAD/mainOpenSimAD.py
+++ b/UtilsDynamicSimulations/OpenSimAD/mainOpenSimAD.py
@@ -581,14 +581,14 @@ def run_tracking(baseDir, dataDir, subject, settings, case='0',
     
     # Paths
     pathGenericTemplates = os.path.join(baseDir, "OpenSimPipeline")
-    # Default dummy motion path
     pathDummyMotion = os.path.join(pathGenericTemplates, "MuscleAnalysis", 
                                    'DummyMotion.mot')
     
     # These are the ranges of motion used to fit the polynomial coefficients.
     # We do not want the experimental data to be out of these ranges. If they
     # are, we make them larger and fit polynomial coefficients specific to the
-    # trial being processed.
+    # trial being processed. These are also the bounds used in the optimal
+    # control problem.
     polynomial_bounds = {
             'hip_flexion_l': {'max': 120, 'min': -30},
             'hip_flexion_r': {'max': 120, 'min': -30},
@@ -606,8 +606,8 @@ def run_tracking(baseDir, dataDir, subject, settings, case='0',
             'subtalar_angle_r': {'max': 35, 'min': -35},
             'mtp_angle_l': {'max': 5, 'min': -45},
             'mtp_angle_r': {'max': 5, 'min': -45}}
-    # Sanity check: ensure that the Qs to track are within the bounds
-    # used to define the polynomials.
+    # Check if the Qs (coordinate values) to track are within the bounds
+    # used to define the polynomials. If not, adjust the polynomial bounds.
     from utilsOpenSimAD import checkQsWithinPolynomialBounds
     updated_bounds = checkQsWithinPolynomialBounds(
         dataToTrack_Qs_nsc, polynomial_bounds, coordinates_toTrack_l)
@@ -1047,8 +1047,8 @@ def run_tracking(baseDir, dataDir, subject, settings, case='0',
         nF_col = opti.variable(nMuscles, d*N)
         opti.subject_to(opti.bounded(lw['Fj'], ca.vec(nF_col), uw['Fj']))
         opti.set_initial(nF_col, w0['Fj'].to_numpy().T)
-        assert np.alltrue(lw['Fj'] <= ca.vec(w0['Fj'].to_numpy().T).full()), "Issue with lower bound muscle force (collocation points)"
-        assert np.alltrue(uw['Fj'] >= ca.vec(w0['Fj'].to_numpy().T).full()), "Issue with upper bound muscle force (collocation points)"
+        assert np.alltrue(lw['Fj'] <= ca.vec(w0['Fj'].to_numpy().T).full()), "Issue with lower bound muscle forces (collocation points)"
+        assert np.alltrue(uw['Fj'] >= ca.vec(w0['Fj'].to_numpy().T).full()), "Issue with upper bound muscle forces (collocation points)"
         # Joint position at mesh points.
         Qs = opti.variable(nJoints, N+1)
         opti.subject_to(opti.bounded(lw['Qsk'], ca.vec(Qs), uw['Qsk']))

--- a/UtilsDynamicSimulations/OpenSimAD/mainOpenSimAD.py
+++ b/UtilsDynamicSimulations/OpenSimAD/mainOpenSimAD.py
@@ -538,11 +538,90 @@ def run_tracking(baseDir, dataDir, subject, settings, case='0',
         dampingArm = 0.1
         f_linearPassiveArmTorque = linarPassiveTorque(stiffnessArm, dampingArm)
         
+    # %% Kinematic data to track.
+    from utilsOpenSimAD import getIK, filterDataFrame
+    from utilsOpenSimAD import interpolateDataFrame, selectDataFrame
+    pathIK = os.path.join(pathIKFolder, trialName + '.mot')
+    Qs_fromIK = getIK(pathIK, joints)
+    # Filtering.
+    if filter_Qs_toTrack:
+        Qs_fromIK_filter = filterDataFrame(
+            Qs_fromIK, cutoff_frequency=cutoff_freq_Qs)
+    else:
+        Qs_fromIK_filter = Qs_fromIK           
+    # Interpolation.
+    Qs_fromIK_interp = interpolateDataFrame(
+        Qs_fromIK_filter, timeIntervals[0], timeIntervals[1], N)
+    Qs_toTrack = copy.deepcopy(Qs_fromIK_interp)
+    # We do not want to down-sample before differentiating the splines.
+    Qs_fromIK_sel = selectDataFrame(
+        Qs_fromIK_filter, timeIntervals[0], timeIntervals[1])
+    Qs_toTrack_s = copy.deepcopy(Qs_fromIK_sel) 
+    nEl_toTrack = len(coordinates_toTrack)
+    # Individual coordinate weigths. Option to weight the contribution of the
+    # coordinates to the cost terms differently. This applies for coordinate
+    # values, speeds, and accelerations tracking.
+    w_dataToTrack = np.ones((nEl_toTrack,1))
+    coordinates_toTrack_l = []
+    for count, coord in enumerate(coordinates_toTrack):
+        coordinates_toTrack_l.append(coord)
+        if 'weight' in coordinates_toTrack[coord]:
+            w_dataToTrack[count, 0] = coordinates_toTrack[coord]['weight']      
+    idx_coordinates_toTrack = getIndices(joints, coordinates_toTrack_l)
+    
+    from utilsOpenSimAD import scaleDataFrame, selectFromDataFrame     
+    dataToTrack_Qs_nsc = selectFromDataFrame(
+        Qs_toTrack, coordinates_toTrack_l).to_numpy()[:,1::].T
+        
     # %% Polynomial approximations.
     # Muscle-tendon lengths, velocities, and moment arms are estimated based
     # on polynomial approximations of joint positions and velocities. The
     # polynomial coefficients are fitted based on data from OpenSim and saved
-    # for the current model. This process is automated.
+    # for the current model.
+    
+    # Paths
+    pathGenericTemplates = os.path.join(baseDir, "OpenSimPipeline")
+    # Default dummy motion path
+    pathDummyMotion = os.path.join(pathGenericTemplates, "MuscleAnalysis", 
+                                   'DummyMotion.mot')
+    
+    # These are the ranges of motion used to fit the polynomial coefficients.
+    # We do not want the experimental data to be out of these ranges. If they
+    # are, we make them larger and fit polynomial coefficients specific to the
+    # trial being processed.
+    polynomial_bounds = {
+            'hip_flexion_l': {'max': 120, 'min': -30},
+            'hip_flexion_r': {'max': 120, 'min': -30},
+            'hip_adduction_l': {'max': 20, 'min': -50},
+            'hip_adduction_r': {'max': 20, 'min': -50},
+            'hip_rotation_l': {'max': 35, 'min': -40},
+            'hip_rotation_r': {'max': 35, 'min': -40},
+            'knee_angle_l': {'max': 138, 'min': 0},
+            'knee_angle_r': {'max': 138, 'min': 0},
+            'knee_adduction_l': {'max': 20, 'min': -30},
+            'knee_adduction_r': {'max': 20, 'min': -30},
+            'ankle_angle_l': {'max': 50, 'min': -50},
+            'ankle_angle_r': {'max': 50, 'min': -50},
+            'subtalar_angle_l': {'max': 35, 'min': -35},
+            'subtalar_angle_r': {'max': 35, 'min': -35},
+            'mtp_angle_l': {'max': 5, 'min': -45},
+            'mtp_angle_r': {'max': 5, 'min': -45}}
+    # Sanity check: ensure that the Qs to track are within the bounds
+    # used to define the polynomials.
+    from utilsOpenSimAD import checkQsWithinPolynomialBounds
+    updated_bounds = checkQsWithinPolynomialBounds(
+        dataToTrack_Qs_nsc, polynomial_bounds, coordinates_toTrack_l)
+    type_bounds_polynomials = 'default'
+    if len(updated_bounds) > 0:
+        # Modify the values of polynomial_bounds based on the values in
+        # updated_bounds.  Also, create a dummy motion file specific to the
+        # trial being processed.
+        from utilsOpenSimAD import adjustBoundsAndDummyMotion
+        polynomial_bounds, pathDummyMotion = adjustBoundsAndDummyMotion(
+            polynomial_bounds, updated_bounds, pathDummyMotion,
+            pathModelFolder, trialName, overwriteDummyMotion=False)
+        type_bounds_polynomials = trialName
+    
     from functionCasADiOpenSimAD import polynomialApproximation
     leftPolynomialJoints = [
         'hip_flexion_l', 'hip_adduction_l', 'hip_rotation_l', 'knee_angle_l',
@@ -552,26 +631,25 @@ def run_tracking(baseDir, dataDir, subject, settings, case='0',
         'ankle_angle_r', 'subtalar_angle_r', 'mtp_angle_r']
     if not withMTP:
         leftPolynomialJoints.remove('mtp_angle_l')
-        rightPolynomialJoints.remove('mtp_angle_r')        
-    pathGenericTemplates = os.path.join(baseDir, "OpenSimPipeline") 
-    pathDummyMotion = os.path.join(pathGenericTemplates, "MuscleAnalysis", 
-                                   'DummyMotion.mot')
+        rightPolynomialJoints.remove('mtp_angle_r')    
     
-    # Load polynomials if computed already, compute otherwise.
+    # Load polynomials if computed already, compute otherwise.    
     loadPolynomialData = True
     if (not os.path.exists(os.path.join(
-            pathModelFolder, model_full_name + '_polynomial_r_default.npy'))
+            pathModelFolder, model_full_name + '_polynomial_r_{}.npy'.format(type_bounds_polynomials)))
             or not os.path.exists(os.path.join(
-            pathModelFolder, model_full_name + '_polynomial_l_default.npy'))):
+            pathModelFolder, model_full_name + '_polynomial_l_{}.npy'.format(type_bounds_polynomials)))):
         loadPolynomialData = False        
     from muscleDataOpenSimAD import getPolynomialData
     polynomialData = {}
     polynomialData['r'] = getPolynomialData(
         loadPolynomialData, pathModelFolder, model_full_name, pathDummyMotion, 
-        rightPolynomialJoints, rightSideMuscles, side='r')
+        rightPolynomialJoints, rightSideMuscles, 
+        type_bounds_polynomials=type_bounds_polynomials, side='r')
     polynomialData['l'] = getPolynomialData(
         loadPolynomialData, pathModelFolder, model_full_name, pathDummyMotion, 
-        leftPolynomialJoints, leftSideMuscles, side='l')     
+        leftPolynomialJoints, leftSideMuscles, 
+        type_bounds_polynomials=type_bounds_polynomials, side='l')     
     if loadPolynomialData:
         polynomialData['r'] = polynomialData['r'].item()
         polynomialData['l'] = polynomialData['l'].item()
@@ -619,26 +697,6 @@ def run_tracking(baseDir, dataDir, subject, settings, case='0',
         testPolynomials(
             data4PolynomialFitting, leftPolynomialJoints, leftSideMuscles,
             f_polynomial['l'], polynomialData['l'], momentArmIndices)
-               
-    # These are the ranges of motion used to fit the polynomial coefficients.
-    # We do not want the experimental data to be out of these ranges.
-    polynomial_bounds = {
-            'hip_flexion_l': {'max': 120, 'min': -30},
-            'hip_flexion_r': {'max': 120, 'min': -30},
-            'hip_adduction_l': {'max': 20, 'min': -50},
-            'hip_adduction_r': {'max': 20, 'min': -50},
-            'hip_rotation_l': {'max': 35, 'min': -40},
-            'hip_rotation_r': {'max': 35, 'min': -40},
-            'knee_angle_l': {'max': 138, 'min': 0},
-            'knee_angle_r': {'max': 138, 'min': 0},
-            'knee_adduction_l': {'max': 20, 'min': -30},
-            'knee_adduction_r': {'max': 20, 'min': -30},
-            'ankle_angle_l': {'max': 50, 'min': -50},
-            'ankle_angle_r': {'max': 50, 'min': -50},
-            'subtalar_angle_l': {'max': 35, 'min': -35},
-            'subtalar_angle_r': {'max': 35, 'min': -35},
-            'mtp_angle_l': {'max': 5, 'min': -45},
-            'mtp_angle_r': {'max': 5, 'min': -45}}
     
     # %% External functions.
     # The external function is written in C++ and compiled as a library, which
@@ -699,38 +757,7 @@ def run_tracking(baseDir, dataDir, subject, settings, case='0',
     idxGroundPelvisJointsinF = [F_map['residuals'][joint] 
                                 for joint in groundPelvisJoints]    
     idxJoints4F = [joints.index(joint) 
-                   for joint in list(F_map['residuals'].keys())]
-            
-    # %% Kinematic data to track.
-    from utilsOpenSimAD import getIK, filterDataFrame
-    from utilsOpenSimAD import interpolateDataFrame, selectDataFrame
-    pathIK = os.path.join(pathIKFolder, trialName + '.mot')
-    Qs_fromIK = getIK(pathIK, joints)
-    # Filtering.
-    if filter_Qs_toTrack:
-        Qs_fromIK_filter = filterDataFrame(
-            Qs_fromIK, cutoff_frequency=cutoff_freq_Qs)
-    else:
-        Qs_fromIK_filter = Qs_fromIK           
-    # Interpolation.
-    Qs_fromIK_interp = interpolateDataFrame(
-        Qs_fromIK_filter, timeIntervals[0], timeIntervals[1], N)
-    Qs_toTrack = copy.deepcopy(Qs_fromIK_interp)
-    # We do not want to down-sample before differentiating the splines.
-    Qs_fromIK_sel = selectDataFrame(
-        Qs_fromIK_filter, timeIntervals[0], timeIntervals[1])
-    Qs_toTrack_s = copy.deepcopy(Qs_fromIK_sel) 
-    nEl_toTrack = len(coordinates_toTrack)
-    # Individual coordinate weigths. Option to weight the contribution of the
-    # coordinates to the cost terms differently. This applies for coordinate
-    # values, speeds, and accelerations tracking.
-    w_dataToTrack = np.ones((nEl_toTrack,1))
-    coordinates_toTrack_l = []
-    for count, coord in enumerate(coordinates_toTrack):
-        coordinates_toTrack_l.append(coord)
-        if 'weight' in coordinates_toTrack[coord]:
-            w_dataToTrack[count, 0] = coordinates_toTrack[coord]['weight']      
-    idx_coordinates_toTrack = getIndices(joints, coordinates_toTrack_l)
+                   for joint in list(F_map['residuals'].keys())]    
    
     # %% Helper CasADi functions
     from functionCasADiOpenSimAD import normSumSqr
@@ -778,7 +805,7 @@ def run_tracking(baseDir, dataDir, subject, settings, case='0',
     uw['Fj'] = ca.vec(uw['F'].to_numpy().T * np.ones((1, d*N))).full()
     lw['Fj'] = ca.vec(lw['F'].to_numpy().T * np.ones((1, d*N))).full()
     # Joint positions.
-    uw['Qs'], lw['Qs'], scaling['Qs'] =  bounds.getBoundsPosition()
+    uw['Qs'], lw['Qs'], scaling['Qs'] =  bounds.getBoundsPosition(polynomial_bounds)
     uw['Qsk'] = ca.vec(uw['Qs'].to_numpy().T * np.ones((1, N+1))).full()
     lw['Qsk'] = ca.vec(lw['Qs'].to_numpy().T * np.ones((1, N+1))).full()
     uw['Qsj'] = ca.vec(uw['Qs'].to_numpy().T * np.ones((1, d*N))).full()
@@ -894,10 +921,6 @@ def run_tracking(baseDir, dataDir, subject, settings, case='0',
         w0['Offset'] = guess.getGuessOffset(scaling['Offset'])
             
     # %% Process tracking data.
-    from utilsOpenSimAD import scaleDataFrame, selectFromDataFrame     
-    dataToTrack_Qs_nsc = selectFromDataFrame(
-        Qs_toTrack, coordinates_toTrack_l).to_numpy()[:,1::].T
-    
     # Splining.
     Qs_spline = Qs_toTrack_s.copy()
     Qds_spline = Qs_toTrack_s.copy()
@@ -955,14 +978,6 @@ def run_tracking(baseDir, dataDir, subject, settings, case='0',
         Qds_spline_interp, joints).to_numpy()[:,1::].T            
     refData_Qdds_nsc = selectFromDataFrame(
         Qdds_spline_interp, joints).to_numpy()[:,1::].T
-        
-    # Sanity check: ensure that the Qs to track are within the bounds
-    # used to define the polynomials.
-    from utilsOpenSimAD import checkQsWithinPolynomialBounds
-    successCheckPoly = checkQsWithinPolynomialBounds(
-        dataToTrack_Qs_nsc, polynomial_bounds, coordinates_toTrack_l)
-    if not successCheckPoly:
-        print('WARNING: Experimental data out of polynomial range.')
             
     # %% Update bounds if coordinate constraints.
     if coordinate_constraints:
@@ -1014,26 +1029,26 @@ def run_tracking(baseDir, dataDir, subject, settings, case='0',
         a = opti.variable(nMuscles, N+1)
         opti.subject_to(opti.bounded(lw['Ak'], ca.vec(a), uw['Ak']))
         opti.set_initial(a, w0['A'].to_numpy().T)
-        assert np.alltrue(lw['Ak'] <= ca.vec(w0['A'].to_numpy().T).full()), "lw Muscle activation"
-        assert np.alltrue(uw['Ak'] >= ca.vec(w0['A'].to_numpy().T).full()), "uw Muscle activation"
+        assert np.alltrue(lw['Ak'] <= ca.vec(w0['A'].to_numpy().T).full()), "Issue with lower bound muscle activations"
+        assert np.alltrue(uw['Ak'] >= ca.vec(w0['A'].to_numpy().T).full()), "Issue with upper bound muscle activations"
         # Muscle activation at collocation points.
         a_col = opti.variable(nMuscles, d*N)
         opti.subject_to(opti.bounded(lw['Aj'], ca.vec(a_col), uw['Aj']))
         opti.set_initial(a_col, w0['Aj'].to_numpy().T)
-        assert np.alltrue(lw['Aj'] <= ca.vec(w0['Aj'].to_numpy().T).full()), "lw Muscle activation col"
-        assert np.alltrue(uw['Aj'] >= ca.vec(w0['Aj'].to_numpy().T).full()), "uw Muscle activation col"
+        assert np.alltrue(lw['Aj'] <= ca.vec(w0['Aj'].to_numpy().T).full()), "Issue with lower bound muscle activations (collocation points)"
+        assert np.alltrue(uw['Aj'] >= ca.vec(w0['Aj'].to_numpy().T).full()), "Issue with upper bound muscle activations (collocation points)"
         # Muscle force at mesh points.
         nF = opti.variable(nMuscles, N+1)
         opti.subject_to(opti.bounded(lw['Fk'], ca.vec(nF), uw['Fk']))
         opti.set_initial(nF, w0['F'].to_numpy().T)
-        assert np.alltrue(lw['Fk'] <= ca.vec(w0['F'].to_numpy().T).full()), "lw Muscle force"
-        assert np.alltrue(uw['Fk'] >= ca.vec(w0['F'].to_numpy().T).full()), "uw Muscle force"
+        assert np.alltrue(lw['Fk'] <= ca.vec(w0['F'].to_numpy().T).full()), "Issue with lower bound muscle forces"
+        assert np.alltrue(uw['Fk'] >= ca.vec(w0['F'].to_numpy().T).full()), "Issue with upper bound muscle forces"
         # Muscle force at collocation points.
         nF_col = opti.variable(nMuscles, d*N)
         opti.subject_to(opti.bounded(lw['Fj'], ca.vec(nF_col), uw['Fj']))
         opti.set_initial(nF_col, w0['Fj'].to_numpy().T)
-        assert np.alltrue(lw['Fj'] <= ca.vec(w0['Fj'].to_numpy().T).full()), "lw Muscle force col"
-        assert np.alltrue(uw['Fj'] >= ca.vec(w0['Fj'].to_numpy().T).full()), "uw Muscle force col"
+        assert np.alltrue(lw['Fj'] <= ca.vec(w0['Fj'].to_numpy().T).full()), "Issue with lower bound muscle force (collocation points)"
+        assert np.alltrue(uw['Fj'] >= ca.vec(w0['Fj'].to_numpy().T).full()), "Issue with upper bound muscle force (collocation points)"
         # Joint position at mesh points.
         Qs = opti.variable(nJoints, N+1)
         opti.subject_to(opti.bounded(lw['Qsk'], ca.vec(Qs), uw['Qsk']))
@@ -1043,15 +1058,15 @@ def run_tracking(baseDir, dataDir, subject, settings, case='0',
                 (w0['Qs'].to_numpy().T.shape[0], 1))), axis=1)
         opti.set_initial(Qs, guessQsEnd)
         # Small margin to account for filtering.
-        assert np.alltrue(lw['Qsk'] - np.pi/180 <= ca.vec(guessQsEnd).full()), "lw Joint position"
-        assert np.alltrue(uw['Qsk'] + np.pi/180 >= ca.vec(guessQsEnd).full()), "uw Joint position"
+        assert np.alltrue(lw['Qsk'] - np.pi/180 <= ca.vec(guessQsEnd).full()), "Issue with lower bound coordinate values"
+        assert np.alltrue(uw['Qsk'] + np.pi/180 >= ca.vec(guessQsEnd).full()), "Issue with upper bound coordinate values"
         # Joint position at collocation points.
         Qs_col = opti.variable(nJoints, d*N)
         opti.subject_to(opti.bounded(lw['Qsj'], ca.vec(Qs_col), uw['Qsj']))
         opti.set_initial(Qs_col, w0['Qsj'].to_numpy().T)
         # Small margin to account for filtering.
-        assert np.alltrue(lw['Qsj'] - np.pi/180 <= ca.vec(w0['Qsj'].to_numpy().T).full()), "lw Joint position col"
-        assert np.alltrue(uw['Qsj'] + np.pi/180 >= ca.vec(w0['Qsj'].to_numpy().T).full()), "uw Joint position col"
+        assert np.alltrue(lw['Qsj'] - np.pi/180 <= ca.vec(w0['Qsj'].to_numpy().T).full()), "Issue with lower bound coordinate values (collocation points)"
+        assert np.alltrue(uw['Qsj'] + np.pi/180 >= ca.vec(w0['Qsj'].to_numpy().T).full()), "Issue with upper bound coordinate values (collocation points)"
         # Joint velocity at mesh points.
         Qds = opti.variable(nJoints, N+1)
         opti.subject_to(opti.bounded(lw['Qdsk'], ca.vec(Qds), uw['Qdsk']))
@@ -1060,73 +1075,73 @@ def run_tracking(baseDir, dataDir, subject, settings, case='0',
                 w0['Qds'].to_numpy().T[:,-1], 
                 (w0['Qds'].to_numpy().T.shape[0], 1))), axis=1)
         opti.set_initial(Qds, guessQdsEnd)
-        assert np.alltrue(lw['Qdsk'] <= ca.vec(guessQdsEnd).full()), "lw Joint velocity"
-        assert np.alltrue(uw['Qdsk'] >= ca.vec(guessQdsEnd).full()), "uw Joint velocity"        
+        assert np.alltrue(lw['Qdsk'] <= ca.vec(guessQdsEnd).full()), "Issue with lower bound coordinate speeds"
+        assert np.alltrue(uw['Qdsk'] >= ca.vec(guessQdsEnd).full()), "Issue with upper bound coordinate speeds"        
         # Joint velocity at collocation points.
         Qds_col = opti.variable(nJoints, d*N)
         opti.subject_to(opti.bounded(lw['Qdsj'], ca.vec(Qds_col), uw['Qdsj']))
         opti.set_initial(Qds_col, w0['Qdsj'].to_numpy().T)
-        assert np.alltrue(lw['Qdsj'] <= ca.vec(w0['Qdsj'].to_numpy().T).full()), "lw Joint velocity col"
-        assert np.alltrue(uw['Qdsj'] >= ca.vec(w0['Qdsj'].to_numpy().T).full()), "uw Joint velocity col"
+        assert np.alltrue(lw['Qdsj'] <= ca.vec(w0['Qdsj'].to_numpy().T).full()), "Issue with lower bound coordinate speeds (collocation points)"
+        assert np.alltrue(uw['Qdsj'] >= ca.vec(w0['Qdsj'].to_numpy().T).full()), "Issue with upper bound coordinate speeds (collocation points)"
         if withArms:
             # Arm activation at mesh points.
             aArm = opti.variable(nArmJoints, N+1)
             opti.subject_to(opti.bounded(lw['ArmAk'], ca.vec(aArm), uw['ArmAk']))
             opti.set_initial(aArm, w0['ArmA'].to_numpy().T)
-            assert np.alltrue(lw['ArmAk'] <= ca.vec(w0['ArmA'].to_numpy().T).full()), "lw Arm activation"
-            assert np.alltrue(uw['ArmAk'] >= ca.vec(w0['ArmA'].to_numpy().T).full()), "uw Arm activation"
+            assert np.alltrue(lw['ArmAk'] <= ca.vec(w0['ArmA'].to_numpy().T).full()), "Issue with lower bound arm activations"
+            assert np.alltrue(uw['ArmAk'] >= ca.vec(w0['ArmA'].to_numpy().T).full()), "Issue with upper bound arm activations"
             # Arm activation at collocation points.
             aArm_col = opti.variable(nArmJoints, d*N)
             opti.subject_to(opti.bounded(lw['ArmAj'], ca.vec(aArm_col), uw['ArmAj']))
             opti.set_initial(aArm_col, w0['ArmAj'].to_numpy().T)
-            assert np.alltrue(lw['ArmAj'] <= ca.vec(w0['ArmAj'].to_numpy().T).full()), "lw Arm activation col"
-            assert np.alltrue(uw['ArmAj'] >= ca.vec(w0['ArmAj'].to_numpy().T).full()), "uw Arm activation col"
+            assert np.alltrue(lw['ArmAj'] <= ca.vec(w0['ArmAj'].to_numpy().T).full()), "Issue with lower bound arm activations (collocation points)"
+            assert np.alltrue(uw['ArmAj'] >= ca.vec(w0['ArmAj'].to_numpy().T).full()), "Issue with upper bound arm activations (collocation points)"
         if withLumbarCoordinateActuators:
             # Lumbar activation at mesh points.
             aLumbar = opti.variable(nLumbarJoints, N+1)
             opti.subject_to(opti.bounded(lw['LumbarAk'], ca.vec(aLumbar), uw['LumbarAk']))
             opti.set_initial(aLumbar, w0['LumbarA'].to_numpy().T)
-            assert np.alltrue(lw['LumbarAk'] <= ca.vec(w0['LumbarA'].to_numpy().T).full()), "lw Lumbar activation"
-            assert np.alltrue(uw['LumbarAk'] >= ca.vec(w0['LumbarA'].to_numpy().T).full()), "uw Lumbar activation"
+            assert np.alltrue(lw['LumbarAk'] <= ca.vec(w0['LumbarA'].to_numpy().T).full()), "Issue with lower bound lumbar activations"
+            assert np.alltrue(uw['LumbarAk'] >= ca.vec(w0['LumbarA'].to_numpy().T).full()), "Issue with upper bound lumbar activations"
             # Lumbar activation at collocation points.
             aLumbar_col = opti.variable(nLumbarJoints, d*N)
             opti.subject_to(opti.bounded(lw['LumbarAj'], ca.vec(aLumbar_col), uw['LumbarAj']))
             opti.set_initial(aLumbar_col, w0['LumbarAj'].to_numpy().T)
-            assert np.alltrue(lw['LumbarAj'] <= ca.vec(w0['LumbarAj'].to_numpy().T).full()), "lw Lumbar activation col"
-            assert np.alltrue(uw['LumbarAj'] >= ca.vec(w0['LumbarAj'].to_numpy().T).full()), "uw Lumbar activation col"
+            assert np.alltrue(lw['LumbarAj'] <= ca.vec(w0['LumbarAj'].to_numpy().T).full()), "Issue with lower bound lumbar activations (collocation points)"
+            assert np.alltrue(uw['LumbarAj'] >= ca.vec(w0['LumbarAj'].to_numpy().T).full()), "Issue with upper bound lumbar activations (collocation points)"
         # Controls.
         # Muscle activation derivative at mesh points.
         aDt = opti.variable(nMuscles, N)
         opti.subject_to(opti.bounded(lw['ADtk'], ca.vec(aDt), uw['ADtk']))
         opti.set_initial(aDt, w0['ADt'].to_numpy().T)
-        assert np.alltrue(lw['ADtk'] <= ca.vec(w0['ADt'].to_numpy().T).full()), "lw Muscle activation derivative"
-        assert np.alltrue(uw['ADtk'] >= ca.vec(w0['ADt'].to_numpy().T).full()), "uw Muscle activation derivative"
+        assert np.alltrue(lw['ADtk'] <= ca.vec(w0['ADt'].to_numpy().T).full()), "Issue with lower bound muscle activation derivatives"
+        assert np.alltrue(uw['ADtk'] >= ca.vec(w0['ADt'].to_numpy().T).full()), "Issue with upper bound muscle activation derivatives"
         if withArms:
             # Arm excitation at mesh points.
             eArm = opti.variable(nArmJoints, N)
             opti.subject_to(opti.bounded(lw['ArmEk'], ca.vec(eArm), uw['ArmEk']))
             opti.set_initial(eArm, w0['ArmE'].to_numpy().T)
-            assert np.alltrue(lw['ArmEk'] <= ca.vec(w0['ArmE'].to_numpy().T).full()), "lw Arm excitation"
-            assert np.alltrue(uw['ArmEk'] >= ca.vec(w0['ArmE'].to_numpy().T).full()), "uw Arm excitation"
+            assert np.alltrue(lw['ArmEk'] <= ca.vec(w0['ArmE'].to_numpy().T).full()), "Issue with lower bound arm excitations"
+            assert np.alltrue(uw['ArmEk'] >= ca.vec(w0['ArmE'].to_numpy().T).full()), "Issue with upper bound arm excitations"
         if withLumbarCoordinateActuators:
             # Lumbar excitation at mesh points.
             eLumbar = opti.variable(nLumbarJoints, N)
             opti.subject_to(opti.bounded(lw['LumbarEk'], ca.vec(eLumbar), uw['LumbarEk']))
             opti.set_initial(eLumbar, w0['LumbarE'].to_numpy().T)
-            assert np.alltrue(lw['LumbarEk'] <= ca.vec(w0['LumbarE'].to_numpy().T).full()), "lw Lumbar excitation"
-            assert np.alltrue(uw['LumbarEk'] >= ca.vec(w0['LumbarE'].to_numpy().T).full()), "uw Lumbar excitation"
+            assert np.alltrue(lw['LumbarEk'] <= ca.vec(w0['LumbarE'].to_numpy().T).full()), "Issue with lower bound lumbar excitations"
+            assert np.alltrue(uw['LumbarEk'] >= ca.vec(w0['LumbarE'].to_numpy().T).full()), "Issue with upper bound lumbar excitations"
         # Muscle force derivative at mesh points.
         nFDt = opti.variable(nMuscles, N)
         opti.subject_to(opti.bounded(lw['FDtk'], ca.vec(nFDt), uw['FDtk']))
         opti.set_initial(nFDt, w0['FDt'].to_numpy().T)
-        assert np.alltrue(lw['FDtk'] <= ca.vec(w0['FDt'].to_numpy().T).full()), "lw Muscle force derivative"
-        assert np.alltrue(uw['FDtk'] >= ca.vec(w0['FDt'].to_numpy().T).full()), "uw Muscle force derivative"
+        assert np.alltrue(lw['FDtk'] <= ca.vec(w0['FDt'].to_numpy().T).full()), "Issue with lower bound muscle force derivatives"
+        assert np.alltrue(uw['FDtk'] >= ca.vec(w0['FDt'].to_numpy().T).full()), "Issue with upper bound muscle force derivatives"
         # Joint velocity derivative (acceleration) at mesh points.
         Qdds = opti.variable(nJoints, N)
         opti.subject_to(opti.bounded(lw['Qddsk'], ca.vec(Qdds), uw['Qddsk']))
         opti.set_initial(Qdds, w0['Qdds'].to_numpy().T)
-        assert np.alltrue(lw['Qddsk'] <= ca.vec(w0['Qdds'].to_numpy().T).full()), "lw Joint velocity derivative"
-        assert np.alltrue(uw['Qddsk'] >= ca.vec(w0['Qdds'].to_numpy().T).full()), "uw Joint velocity derivative"
+        assert np.alltrue(lw['Qddsk'] <= ca.vec(w0['Qdds'].to_numpy().T).full()), "Issue with lower bound coordinate speed derivatives"
+        assert np.alltrue(uw['Qddsk'] >= ca.vec(w0['Qdds'].to_numpy().T).full()), "Issue with upper bound coordinate speed derivatives"
         # Reserve actuator at mesh points.
         if withReserveActuators:
             rAct = {}
@@ -1134,8 +1149,8 @@ def run_tracking(baseDir, dataDir, subject, settings, case='0',
                 rAct[c_j] = opti.variable(1, N)
                 opti.subject_to(opti.bounded(lw['rActk'][c_j], ca.vec(rAct[c_j]), uw['rActk'][c_j]))
                 opti.set_initial(rAct[c_j], w0['rAct'][c_j].to_numpy().T)
-                assert np.alltrue(lw['rActk'][c_j] <= ca.vec(w0['rAct'][c_j].to_numpy().T).full()), "lw reserve"
-                assert np.alltrue(uw['rActk'][c_j] >= ca.vec(w0['rAct'][c_j].to_numpy().T).full()), "uw reserve"
+                assert np.alltrue(lw['rActk'][c_j] <= ca.vec(w0['rAct'][c_j].to_numpy().T).full()), "Issue with lower bound reserve actuators"
+                assert np.alltrue(uw['rActk'][c_j] >= ca.vec(w0['rAct'][c_j].to_numpy().T).full()), "Issue with upper bound reserve actuators"
             
         # %% Plots initial guess vs bounds.
         plotGuessVsBounds = False

--- a/UtilsDynamicSimulations/OpenSimAD/muscleDataOpenSimAD.py
+++ b/UtilsDynamicSimulations/OpenSimAD/muscleDataOpenSimAD.py
@@ -191,7 +191,7 @@ def getPolynomialData(loadPolynomialData, pathModelFolder, modelName='',
         
     else:
         path_data4PolynomialFitting = os.path.join(
-            pathModelFolder, 'data4PolynomialFitting_{}.npy'.format(modelName))
+            pathModelFolder, 'data4PolynomialFitting_{}_{}.npy'.format(modelName, type_bounds_polynomials))
         # Generate polynomial data.
         if (not os.path.exists(path_data4PolynomialFitting) or 
             overwritedata4PolynomialFitting):            


### PR DESCRIPTION
Addresses #49. 

We now check if the coordinates to track are within the default bounds, if not then we adjust the bounds accordingly. This holds for the bounds used to fit the polynomials and for the bounds used to constrain the design variables during optimization. These sets of bounds are now always the same. 

If we adjust the bounds, then we use trial-specific polynomial coefficients. That way we can easily reproduce results, and do not have things being updated depending on the trial.

Test I have done:
- I verified that I got (almost) the same results for a motion that is within the bounds
- I checked that all was working as expected for a trial outside of the default bounds.
