### PR TITLE
Using expressing graph directly instead of external function to leverage SX

### DIFF
--- a/Examples/example_walking_opensimAD.py
+++ b/Examples/example_walking_opensimAD.py
@@ -45,9 +45,9 @@
 '''
 
 # %% Select the example you want to run.
-runTorqueDrivenProblem = True
+runTorqueDrivenProblem = False
 runMuscleDrivenProblem = False
-runComparison = False
+runComparison = True
 
 # %% Directories, paths, and imports. You should not need to change anything.
 import os
@@ -179,7 +179,7 @@ if runTorqueDrivenProblem:
 
 # %% Sub-example 2: walking simulation with muscle-driven model.
 # Insert a string to "name" you case.
-case = 'muscle_driven'
+case = 'muscle_driven_not_expand'
 
 # Prepare inputs for dynamic simulation (this will be skipped if already done):
 #   - Download data from OpenCap database
@@ -232,7 +232,7 @@ if runMuscleDrivenProblem:
     #   - Windows (Windows 10):    converged in 586 iterations
     #   - macOS   (Monterey 12.2): converged in 499 iterations
     #   - Linux   (Ubuntu 20.04):  converged in 645 iterations
-    run_tracking(baseDir, dataFolder, session_id, settings, case=case)
+    # run_tracking(baseDir, dataFolder, session_id, settings, case=case)
 
     # Plot some results.
     plotResultsOpenSimAD(dataFolder, session_id, trial_name, settings, [case])
@@ -240,4 +240,4 @@ if runMuscleDrivenProblem:
 # %% Comparison torque-driven vs. muscle-driven model.
 if runComparison:
     plotResultsOpenSimAD(dataFolder, session_id, trial_name, settings,
-                        ['torque_driven', 'muscle_driven'])
+                        ['muscle_driven_not_expand', 'muscle_driven_expand'])

--- a/Examples/example_walking_opensimAD.py
+++ b/Examples/example_walking_opensimAD.py
@@ -47,7 +47,7 @@
 # %% Select the example you want to run.
 runTorqueDrivenProblem = False
 runMuscleDrivenProblem = False
-runComparison = True
+runComparison = False
 
 # %% Directories, paths, and imports. You should not need to change anything.
 import os

--- a/Examples/example_walking_opensimAD.py
+++ b/Examples/example_walking_opensimAD.py
@@ -181,7 +181,7 @@ settings['meshDensity'] = 50
 # Run the dynamic simulation.
 if runTorqueDrivenProblem:
     # Here are some reference numbers for convergence of the problem. Note that
-    # it might vary depending on the machine you are using.
+    # it might vary depending on the machine and the package versions.
     #   - Windows (Windows 10):    converged in 99 iterations
     #   - macOS   (Monterey 12.2): converged in 110 iterations 
     #   - Linux   (Ubuntu 20.04):  converged in 109 iterations
@@ -192,7 +192,7 @@ if runTorqueDrivenProblem:
 
 # %% Sub-example 2: walking simulation with muscle-driven model.
 # Insert a string to "name" you case.
-case = 'muscle_driven_SX'
+case = 'muscle_driven_MX'
 
 # Prepare inputs for dynamic simulation (this will be skipped if already done):
 #   - Download data from OpenCap database
@@ -202,7 +202,7 @@ case = 'muscle_driven_SX'
 settings = processInputsOpenSimAD(
     baseDir, dataFolder, session_id, trial_name, motion_type, 
     time_window=time_window, treadmill_speed=treadmill_speed,
-    useExpressionGraphFunction=True)
+    useExpressionGraphFunction=False)
 
 # Add periodic constraints to the problem. This will constrain initial and
 # final states of the problem to be the same. This is useful for obtaining
@@ -242,7 +242,7 @@ settings['meshDensity'] = 50
 # Run the dynamic simulation.
 if runMuscleDrivenProblem:
     # Here are some reference numbers for convergence of the problem. Note that
-    # it might vary depending on the machine you are using.
+    # it might vary depending on the machine and the package versions.
     #   - Windows (Windows 10):    converged in 586 iterations
     #   - macOS   (Monterey 12.2): converged in 499 iterations
     #   - Linux   (Ubuntu 20.04):  converged in 645 iterations

--- a/Examples/example_walking_opensimAD.py
+++ b/Examples/example_walking_opensimAD.py
@@ -45,8 +45,8 @@
 '''
 
 # %% Select the example you want to run.
-runTorqueDrivenProblem = False
-runMuscleDrivenProblem = True
+runTorqueDrivenProblem = True
+runMuscleDrivenProblem = False
 runComparison = False
 
 # %% Directories, paths, and imports. You should not need to change anything.
@@ -180,19 +180,13 @@ settings['meshDensity'] = 50
 
 # Run the dynamic simulation.
 if runTorqueDrivenProblem:
-    # Here are some reference numbers for convergence of the problem. Note that
-    # it might vary depending on the machine and the package versions.
-    #   - Windows (Windows 10):    converged in 99 iterations
-    #   - macOS   (Monterey 12.2): converged in 110 iterations 
-    #   - Linux   (Ubuntu 20.04):  converged in 109 iterations
     run_tracking(baseDir, dataFolder, session_id, settings, case=case)
-
     # Plot some results.
     plotResultsOpenSimAD(dataFolder, session_id, trial_name, settings, [case])
 
 # %% Sub-example 2: walking simulation with muscle-driven model.
 # Insert a string to "name" you case.
-case = 'muscle_driven_MX'
+case = 'muscle_driven'
 
 # Prepare inputs for dynamic simulation (this will be skipped if already done):
 #   - Download data from OpenCap database
@@ -201,8 +195,7 @@ case = 'muscle_driven_MX'
 #   - Generate external function (OpenSimAD)
 settings = processInputsOpenSimAD(
     baseDir, dataFolder, session_id, trial_name, motion_type, 
-    time_window=time_window, treadmill_speed=treadmill_speed,
-    useExpressionGraphFunction=False)
+    time_window=time_window, treadmill_speed=treadmill_speed)
 
 # Add periodic constraints to the problem. This will constrain initial and
 # final states of the problem to be the same. This is useful for obtaining
@@ -241,17 +234,11 @@ settings['meshDensity'] = 50
 
 # Run the dynamic simulation.
 if runMuscleDrivenProblem:
-    # Here are some reference numbers for convergence of the problem. Note that
-    # it might vary depending on the machine and the package versions.
-    #   - Windows (Windows 10):    converged in 586 iterations
-    #   - macOS   (Monterey 12.2): converged in 499 iterations
-    #   - Linux   (Ubuntu 20.04):  converged in 645 iterations
     run_tracking(baseDir, dataFolder, session_id, settings, case=case)
-
     # Plot some results.
     plotResultsOpenSimAD(dataFolder, session_id, trial_name, settings, [case])
 
 # %% Comparison torque-driven vs. muscle-driven model.
 if runComparison:
     plotResultsOpenSimAD(dataFolder, session_id, trial_name, settings,
-                        ['torque_driven_SX', 'torque_driven_MX'])
+                        ['torque_driven', 'muscle_driven'])

--- a/Examples/example_walking_opensimAD.py
+++ b/Examples/example_walking_opensimAD.py
@@ -46,7 +46,7 @@
 
 # %% Select the example you want to run.
 runTorqueDrivenProblem = False
-runMuscleDrivenProblem = False
+runMuscleDrivenProblem = True
 runComparison = False
 
 # %% Directories, paths, and imports. You should not need to change anything.
@@ -192,7 +192,7 @@ if runTorqueDrivenProblem:
 
 # %% Sub-example 2: walking simulation with muscle-driven model.
 # Insert a string to "name" you case.
-case = 'muscle_driven_not_expand'
+case = 'muscle_driven_SX'
 
 # Prepare inputs for dynamic simulation (this will be skipped if already done):
 #   - Download data from OpenCap database
@@ -201,7 +201,8 @@ case = 'muscle_driven_not_expand'
 #   - Generate external function (OpenSimAD)
 settings = processInputsOpenSimAD(
     baseDir, dataFolder, session_id, trial_name, motion_type, 
-    time_window=time_window, treadmill_speed=treadmill_speed)
+    time_window=time_window, treadmill_speed=treadmill_speed,
+    useExpressionGraphFunction=True)
 
 # Add periodic constraints to the problem. This will constrain initial and
 # final states of the problem to be the same. This is useful for obtaining
@@ -245,7 +246,7 @@ if runMuscleDrivenProblem:
     #   - Windows (Windows 10):    converged in 586 iterations
     #   - macOS   (Monterey 12.2): converged in 499 iterations
     #   - Linux   (Ubuntu 20.04):  converged in 645 iterations
-    # run_tracking(baseDir, dataFolder, session_id, settings, case=case)
+    run_tracking(baseDir, dataFolder, session_id, settings, case=case)
 
     # Plot some results.
     plotResultsOpenSimAD(dataFolder, session_id, trial_name, settings, [case])
@@ -253,4 +254,4 @@ if runMuscleDrivenProblem:
 # %% Comparison torque-driven vs. muscle-driven model.
 if runComparison:
     plotResultsOpenSimAD(dataFolder, session_id, trial_name, settings,
-                        ['muscle_driven_not_expand', 'muscle_driven_expand'])
+                        ['torque_driven_SX', 'torque_driven_MX'])

--- a/UtilsDynamicSimulations/OpenSimAD/mainOpenSimAD.py
+++ b/UtilsDynamicSimulations/OpenSimAD/mainOpenSimAD.py
@@ -764,13 +764,13 @@ def run_tracking(baseDir, dataDir, subject, settings, case='0',
     # problem. It returns joint torques as well as some outputs of interest, 
     # eg segment origins, that you may want to use for the problem formulation.
     # The external function is written in C++ and compiled as an executable,
-    # which when called with numerical values returns the undelrying expression
+    # which when called with numerical values returns the underlying expression
     # graph as a function foo. We used to generate c code from the expression
     # graph using CasADi and then compile the c code as a library to be called
     # as an external function. This is not necessary anymore. The expression
     # graph is saved as a function that can be called directly with CasADi. This
-    # allows using SX only, whereas actual external functions require MX. For
-    # backward compatibility, we still check if the external function is there.
+    # allows using SX only, whereas actual external functions require MX. We
+    # still support the older approach (useExpressionGraphFunction=False).
 
     F_name = 'F'
     dim = 3*nJoints

--- a/UtilsDynamicSimulations/OpenSimAD/mainOpenSimAD.py
+++ b/UtilsDynamicSimulations/OpenSimAD/mainOpenSimAD.py
@@ -766,9 +766,19 @@ def run_tracking(baseDir, dataDir, subject, settings, case='0',
     suff_tread = ''
     if treadmill:
         suff_tread = '_treadmill'
+        
+    # test
+    import importlib
+    import foo
+    importlib.reload(foo)
+    dim = 100
+    arg = ca.SX.sym('arg', dim)
+    y,_,_ = foo.foo(arg)
+    F = ca.Function('F',[arg],[y])    
+        
     
-    F = ca.external('F', 
-        os.path.join(pathExternalFunctionFolder, 'F' + suff_tread + ext_F))
+    # F = ca.external('F', 
+    #     os.path.join(pathExternalFunctionFolder, 'F' + suff_tread + ext_F))
     F_map = np.load(
         os.path.join(pathExternalFunctionFolder, 
                      'F' + suff_tread + '_map.npy'), allow_pickle=True).item()

--- a/UtilsDynamicSimulations/OpenSimAD/utilsOpenSimAD.py
+++ b/UtilsDynamicSimulations/OpenSimAD/utilsOpenSimAD.py
@@ -129,7 +129,7 @@ def solve_with_bounds(opti, tolerance):
     
     prob = {'x': opti.x, 'f': opti.f, 'g': new_g}
     s_opts = {}
-    s_opts["expand"] = False
+    s_opts["expand"] = True
     s_opts["ipopt.hessian_approximation"] = "limited-memory"
     s_opts["ipopt.mu_strategy"] = "adaptive"
     s_opts["ipopt.max_iter"] = 5000

--- a/UtilsDynamicSimulations/OpenSimAD/utilsOpenSimAD.py
+++ b/UtilsDynamicSimulations/OpenSimAD/utilsOpenSimAD.py
@@ -1809,7 +1809,8 @@ def buildExternalFunction(filename, pathDCAD, CPP_DIR, nInputs,
         shutil.rmtree(pathBuild)
         shutil.rmtree(path_external_functions_filename_install)
         shutil.rmtree(path_external_functions_filename_build)
-    os.remove(path_external_filename_foo)    
+    if os_system == 'Windows':
+        os.remove(path_external_filename_foo)
     
 # %% Download file given url (approach 1).
 def download_file(url, file_name):

--- a/UtilsDynamicSimulations/OpenSimAD/utilsOpenSimAD.py
+++ b/UtilsDynamicSimulations/OpenSimAD/utilsOpenSimAD.py
@@ -531,19 +531,23 @@ def generateExternalFunction(
                                   externalFunctionName + ".cpp")
     pathOutputMap = os.path.join(pathOutputExternalFunctionFolder, 
                                  externalFunctionName + "_map.npy")
-    if platform.system() == 'Windows':
-        ext_F = '.dll'
-    elif platform.system() == 'Darwin':
-        ext_F = '.dylib'
-    elif platform.system() == 'Linux':
-        ext_F = '.so'
-    else:
-        raise ValueError("Platform not supported.")
-    pathOutputDll = os.path.join(pathOutputExternalFunctionFolder, 
-                                 externalFunctionName + ext_F)
+    pathExpressionGraph = os.path.join(pathOutputExternalFunctionFolder, 
+                                       externalFunctionName + '.py')
+
+    # This will be deprecated in the future.
+    # if platform.system() == 'Windows':
+    #     ext_F = '.dll'
+    # elif platform.system() == 'Darwin':
+    #     ext_F = '.dylib'
+    # elif platform.system() == 'Linux':
+    #     ext_F = '.so'
+    # else:
+    #     raise ValueError("Platform not supported.")
+    # pathOutputDll = os.path.join(pathOutputExternalFunctionFolder, 
+    #                              externalFunctionName + ext_F)    
     
     if (overwrite is False and os.path.exists(pathOutputFile) and 
-        os.path.exists(pathOutputMap) and os.path.exists(pathOutputDll)):
+        os.path.exists(pathOutputMap) and os.path.exists(pathExpressionGraph)):
         return      
     else:
         print('Generate external function to leverage automatic differentiation.')

--- a/UtilsDynamicSimulations/OpenSimAD/utilsOpenSimAD.py
+++ b/UtilsDynamicSimulations/OpenSimAD/utilsOpenSimAD.py
@@ -1526,8 +1526,8 @@ def generateExternalFunction(
             3*nCoordinates, treadmill=treadmill, 
             useExpressionGraphFunction=useExpressionGraphFunction)
         
-    # %% Verification..
-    if verifyID:        
+    # %% Verification.
+    if verifyID:
         # Run ID with the .osim file
         pathGenericTemplates = os.path.join(baseDir, "OpenSimPipeline") 
         pathGenericIDFolder = os.path.join(pathGenericTemplates,
@@ -1589,7 +1589,7 @@ def generateExternalFunction(
             vec3 = np.concatenate((vec1,vec2))
 
         if useExpressionGraphFunction:
-            # Approach 2: Expression graph.
+            # Approach 1: Expression graph.
             pathExpressionGraph = os.path.join(
                 pathOutputExternalFunctionFolder, externalFunctionName + '.py')
             if os.path.exists(pathExpressionGraph):


### PR DESCRIPTION
This PR adds the option to leverage the expand functionality of CasADi to use SX only instead of SX-MX. Default is now to use SX only.

The key thing is that using SX is faster than using MX, I believe because it only relies on unary and binary operations. When using OpenSimAD, you are first generating an expression graph and then compiling this expression graph as a CasADi external function that you then call when formulating your optimization problem. The expression graph is made up by a sequence of unary and binary operations, but when compiling it as an external function you somehow lose the ability to call the function with SX and need to use MX instead. However, there is actually no reason for not using the expression graph directly and skip compiling it as an external function. This is what this PR is doing. You can then use SX only using the expand functionality of CasADi. 

As expected, this is affecting the problem. It makes the constraint Jacobian sparser, which is good. It should make the problems solve faster too. It is hard to make apple-to-apple comparisons because the problems converge to different solutions. The thing that makes me think it is all good it that the first 20-30 iterations are the exact same and then the iterations start being different, which makes total sense if the underlying constraint Jacobian, among other, is slightly different.

Some doc from CasADi: https://web.casadi.org/docs/
- The SX data type is used to represent matrices whose elements consist of symbolic expressions made up by a sequence of unary and binary operations.
- The MX type allows, like SX, to build up expressions consisting of a sequence of elementary operations. But unlike SX, these elementary operations are not restricted to be scalar unary or binary operations
- A function object defined by an MX graph that only contains built-in operations (e.g. element-wise operations such as addition, square root, matrix multiplications and calls to SX functions), can be converted into a function defined purely by an SX graph using the syntax: sx_function = mx_function.expand()

Tests I have done:
- Torque-driven walking simulation
    - Confirmed more non-zeros with MX, essentially converged to the same solution
- Muscle-driven walking simulation
    -  Confirmed more non-zeros with MX, essentially converged to the same solution
    - 
![image](https://github.com/stanfordnmbl/opencap-processing/assets/19328993/fccae170-90ce-49af-9fe5-94c39445be63)

- Tested on Windows, Mac, and Ubuntu
 