### PR TITLE
[WIP]: support for getting ik on flat ground -  do not merge, not robust

### DIFF
--- a/Examples/example_alignement.py
+++ b/Examples/example_alignement.py
@@ -1,0 +1,40 @@
+import os
+import sys
+baseDir = os.path.join(os.getcwd(), '..')
+sys.path.append(baseDir)
+
+from utils import download_trial, get_trial_id
+from utilsProcessing import align_markers_with_ground
+from utilsOpenSim import runIKTool
+
+session_id = 'a08ec9d6-24f8-44f7-a59c-f603b7517e4d'
+trial_name = '10mwrt_2'
+
+dataFolder = os.path.join(baseDir, 'Data')
+
+# Get trial id from name.
+trial_id = get_trial_id(session_id,trial_name)    
+
+# Set session path.
+sessionDir = os.path.join(dataFolder, session_id)
+
+# Download data.
+trialName, modelName = download_trial(trial_id,sessionDir,session_id=session_id)
+
+# Align markers with ground.
+pathTRCFile_out = align_markers_with_ground(
+    sessionDir, trialName, 
+    referenceMarker1='r.PSIS_study', referenceMarker2='L.PSIS_study',
+    suffixOutputFileName='aligned',
+    lowpass_cutoff_frequency_for_marker_values=6)
+
+# Run inverse kinematics.
+pathGenericSetupFile = os.path.join(
+    baseDir, 'OpenSimPipeline', 
+    'InverseKinematics', 'Setup_InverseKinematics.xml')
+
+pathScaledModel = os.path.join(sessionDir, 'OpenSimData', 'Model', modelName)
+pathOutputFolder = os.path.join(sessionDir, 'OpenSimData', 'Kinematics')
+
+runIKTool(pathGenericSetupFile, pathScaledModel, pathTRCFile_out,
+          pathOutputFolder)

--- a/Examples/example_gait_analysis.py
+++ b/Examples/example_gait_analysis.py
@@ -66,7 +66,7 @@ trial_id = get_trial_id(session_id,trial_name)
 sessionDir = os.path.join(dataFolder, session_id)
 
 # Download data.
-trialName = download_trial(trial_id,sessionDir,session_id=session_id) 
+trialName, _ = download_trial(trial_id,sessionDir,session_id=session_id) 
 
 # Init gait analysis.
 gait_r = gait_analysis(

--- a/OpenSimPipeline/InverseKinematics/Setup_InverseKinematics.xml
+++ b/OpenSimPipeline/InverseKinematics/Setup_InverseKinematics.xml
@@ -1,0 +1,289 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<OpenSimDocument Version="40000">
+	<InverseKinematicsTool name="generic">
+		<!--Directory used for writing results.-->
+		<results_directory>Unassigned</results_directory>
+		<!--Name of the model file (.osim) to use for inverse kinematics.-->
+		<model_file>Unassigned</model_file>
+		<!--A positive scalar that weights the relative importance of satisfying constraints. A weighting of 'Infinity' (the default) results in the constraints being strictly enforced. Otherwise, the weighted-squared constraint errors are appended to the cost function.-->
+		<constraint_weight>Inf</constraint_weight>
+		<!--The accuracy of the solution in absolute terms. Default is 1e-5. It determines the number of significant digits to which the solution can be trusted.-->
+		<accuracy>1.0000000000000001e-05</accuracy>
+		<!--Markers and coordinates to be considered (tasks) and their weightings. The sum of weighted-squared task errors composes the cost function.-->
+		<IKTaskSet>
+			<objects>
+				<IKMarkerTask name="C7_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>5</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="r_shoulder_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>5</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="L_shoulder_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>5</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="r.ASIS_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>25</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="L.ASIS_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>25</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="r.PSIS_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>25</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="L.PSIS_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>25</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="r_knee_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>30</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="r_mknee_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>30</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="r_ankle_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>30</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="r_mankle_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>30</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="r_toe_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>30</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="r_5meta_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>30</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="r_calc_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>60</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="L_knee_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>30</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="L_mknee_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>30</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="L_ankle_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>30</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="L_mankle_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>30</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="L_toe_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>30</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="L_calc_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>60</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="L_5meta_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>30</weight>
+				</IKMarkerTask>                
+                <IKMarkerTask name="r_lelbow_study">
+                    <!--Whether or not this task will be used during inverse kinematics solve, default is true.-->
+                    <apply>true</apply>
+                    <!--Weight given to the task when solving inverse kinematics problems, default is 0.-->
+                    <weight>5</weight>
+                </IKMarkerTask>
+                <IKMarkerTask name="L_lelbow_study">
+                    <!--Whether or not this task will be used during inverse kinematics solve, default is true.-->
+                    <apply>true</apply>
+                    <!--Weight given to the task when solving inverse kinematics problems, default is 0.-->
+                    <weight>5</weight>
+                </IKMarkerTask>
+                <IKMarkerTask name="r_melbow_study">
+                    <!--Whether or not this task will be used during inverse kinematics solve, default is true.-->
+                    <apply>true</apply>
+                    <!--Weight given to the task when solving inverse kinematics problems, default is 0.-->
+                    <weight>5</weight>
+                </IKMarkerTask>
+                <IKMarkerTask name="L_melbow_study">
+                    <!--Whether or not this task will be used during inverse kinematics solve, default is true.-->
+                    <apply>true</apply>
+                    <!--Weight given to the task when solving inverse kinematics problems, default is 0.-->
+                    <weight>5</weight>
+                </IKMarkerTask>                    
+                <IKMarkerTask name="r_lwrist_study">
+                    <!--Whether or not this task will be used during inverse kinematics solve, default is true.-->
+                    <apply>true</apply>
+                    <!--Weight given to the task when solving inverse kinematics problems, default is 0.-->
+                    <weight>5</weight>
+                </IKMarkerTask>
+                <IKMarkerTask name="L_lwrist_study">
+                    <!--Whether or not this task will be used during inverse kinematics solve, default is true.-->
+                    <apply>true</apply>
+                    <!--Weight given to the task when solving inverse kinematics problems, default is 0.-->
+                    <weight>5</weight>
+                </IKMarkerTask>
+                <IKMarkerTask name="r_mwrist_study">
+                    <!--Whether or not this task will be used during inverse kinematics solve, default is true.-->
+                    <apply>true</apply>
+                    <!--Weight given to the task when solving inverse kinematics problems, default is 0.-->
+                    <weight>5</weight>
+                </IKMarkerTask>
+                <IKMarkerTask name="L_mwrist_study">
+                    <!--Whether or not this task will be used during inverse kinematics solve, default is true.-->
+                    <apply>true</apply>
+                    <!--Weight given to the task when solving inverse kinematics problems, default is 0.-->
+                    <weight>5</weight>
+                </IKMarkerTask>   
+				<IKMarkerTask name="r_thigh1_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>4</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="r_thigh2_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>4</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="r_thigh3_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>4</weight>
+				</IKMarkerTask>				
+				<IKMarkerTask name="L_thigh1_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>4</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="L_thigh2_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>4</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="L_thigh3_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>4</weight>
+				</IKMarkerTask>				
+				<IKMarkerTask name="r_sh1_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>4</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="r_sh2_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>4</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="r_sh3_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>4</weight>
+				</IKMarkerTask>				
+				<IKMarkerTask name="L_sh1_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>4</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="L_sh2_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>4</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="L_sh3_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>4</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="RHJC_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>25</weight>
+				</IKMarkerTask>
+				<IKMarkerTask name="LHJC_study">
+					<!--Whether or not this task will be used during inverse kinematics solve.-->
+					<apply>true</apply>
+					<!--Weight given to a marker or coordinate for solving inverse kinematics problems.-->
+					<weight>25</weight>
+				</IKMarkerTask>
+			</objects>
+			<groups />
+		</IKTaskSet>
+		<!--TRC file (.trc) containing the time history of observations of marker positions obtained during a motion capture experiment. Markers in this file that have a corresponding task and model marker are included.-->
+		<marker_file>Unassigned</marker_file>
+		<!--The name of the storage (.sto or .mot) file containing the time history of coordinate observations. Coordinate values from this file are included if there is a corresponding model coordinate and task. -->
+		<coordinate_file>Unassigned</coordinate_file>
+		<!--The desired time range over which inverse kinematics is solved. The closest start and final times from the provided observations are used to specify the actual time range to be processed.-->
+		<time_range>-Inf Inf</time_range>
+		<!--Flag (true or false) indicating whether or not to report marker errors from the inverse kinematics solution.-->
+		<report_errors>true</report_errors>
+		<!--Name of the resulting inverse kinematics motion (.mot) file.-->
+		<output_motion_file>Unassigned</output_motion_file>
+		<!--Flag indicating whether or not to report model marker locations. Note, model marker locations are expressed in Ground.-->
+		<report_marker_locations>false</report_marker_locations>
+	</InverseKinematicsTool>
+</OpenSimDocument>

--- a/utils.py
+++ b/utils.py
@@ -266,12 +266,12 @@ def download_trial(trial_id, folder, session_id=None):
     os.makedirs(folder,exist_ok=True)
     
     # download model
-    get_model_and_metadata(session_id, folder)
+    modelName = get_model_and_metadata(session_id, folder)
     
     # download trc and mot
     get_motion_data(trial_id,folder)
     
-    return trial['name']
+    return trial['name'], modelName
 
 
 # Get trial ID from name.

--- a/utilsOpenSim.py
+++ b/utilsOpenSim.py
@@ -1,0 +1,33 @@
+import os
+import opensim
+    
+# %% Inverse kinematics.
+def runIKTool(pathGenericSetupFile, pathScaledModel, pathTRCFile,
+              pathOutputFolder, timeRange=[], IKFileName='not_specified'):
+    
+    # Paths
+    if IKFileName == 'not_specified':
+        _, IKFileName = os.path.split(pathTRCFile)
+        IKFileName = IKFileName[:-4]
+    pathOutputMotion = os.path.join(pathOutputFolder, IKFileName + '.mot')
+    pathOutputSetup =  os.path.join(
+        pathOutputFolder, 'Setup_InverseKinematics_' + IKFileName + '.xml')
+    
+    # Setup IK tool.
+    opensim.Logger.setLevelString('error')
+    IKTool = opensim.InverseKinematicsTool(pathGenericSetupFile)            
+    IKTool.setName(IKFileName)
+    IKTool.set_model_file(pathScaledModel)          
+    IKTool.set_marker_file(pathTRCFile)
+    if timeRange:
+        IKTool.set_time_range(0, timeRange[0])
+        IKTool.set_time_range(1, timeRange[-1])
+    IKTool.setResultsDir(pathOutputFolder)                        
+    IKTool.set_report_errors(True)
+    IKTool.set_report_marker_locations(False)
+    IKTool.set_output_motion_file(pathOutputMotion)
+    IKTool.printToXML(pathOutputSetup)
+    command = 'opensim-cmd -o error' + ' run-tool ' + pathOutputSetup
+    os.system(command)
+    
+    return 

--- a/utilsProcessing.py
+++ b/utilsProcessing.py
@@ -27,8 +27,10 @@ import logging
 import opensim
 import numpy as np
 from scipy import signal
+import scipy.interpolate as interpolate
 import matplotlib.pyplot as plt
 from utils import storage_to_dataframe, download_trial, get_trial_id
+from utilsTRC import TRCFile
 
 def lowPassFilter(time, data, lowpass_cutoff_frequency, order=4):
     
@@ -620,3 +622,86 @@ def generate_model_with_contacts(
     model.initSystem()
     model.printToXML(pathOutputModel)
 
+# %% Align marker data with ground.
+# When the checkerboard is not perfectly aligned with the ground, then it might
+# look like if the subject is going uphill or downhill. This function computes
+# the angle between the checkerboard and the ground, and then rotates the
+# marker data such that the checkerboard is aligned with the ground. 
+def align_markers_with_ground(sessionDir, trialName, 
+                              referenceMarker1='r.PSIS_study',
+                              referenceMarker2='L.PSIS_study',
+                              suffixOutputFileName='aligned',
+                              lowpass_cutoff_frequency_for_marker_values=-1,
+                              addOffset=True):
+
+    pathTRCFile = os.path.join(sessionDir, 'MarkerData', trialName + '.trc')
+    trc_file = TRCFile(pathTRCFile)
+    time = trc_file.time
+
+    # Extract data from reference markers.
+    m1 = trc_file.marker(referenceMarker1)
+    m2 = trc_file.marker(referenceMarker2)
+    mid_m = (m1+m2)/2
+    if lowpass_cutoff_frequency_for_marker_values > 0:
+        mid_m = lowPassFilter(
+            time, mid_m, lowpass_cutoff_frequency_for_marker_values)
+    spline = interpolate.InterpolatedUnivariateSpline(
+        time, mid_m[:,1], k=3)
+    splineD1 = spline.derivative(n=1)
+    mid_m_speed = splineD1(time)
+
+    # We assume peak vertical speeds should match across gait cycles.
+    peaks, _ = signal.find_peaks(mid_m_speed, distance=30, 
+                                 width=15, prominence=0.1)
+    
+    # The beginning of the trial is not always great, we here select the gait
+    # cycles that have similar durations (+/-20%).
+    diff_peaks = np.diff([peaks])    
+    for i in range(len(diff_peaks[0])-2, 0, -1):
+        if np.abs(diff_peaks[0][i]-diff_peaks[0][i+1]) > 0.2*diff_peaks[0][i+1]:
+            break
+    
+    # Extract marker data at first and last peaks.
+    pos_start = mid_m[peaks[i+1], :]
+    pos_end = mid_m[peaks[-1], :]
+    
+    # Calculate the original vector.
+    original_vector = pos_end - pos_start
+
+    # The reference vector is the vector along the x-axis.
+    reference_vector = np.array([1, 0, 0])
+    
+    # Calculate the dot product of the two vectors.
+    dot_product = np.dot(reference_vector, original_vector)
+    
+    # Calculate the magnitudes (lengths) of the vectors.
+    magnitude_A = np.linalg.norm(reference_vector)
+    magnitude_B = np.linalg.norm(original_vector)
+    
+    # Calculate the angle between the two vectors in radians.
+    angle_rad = np.arccos(dot_product / (magnitude_A * magnitude_B))
+    
+    # Convert the angle from radians to degrees if needed.
+    angle_deg = np.degrees(angle_rad)
+    
+    # Rotate marker data about the z-axis.
+    trc_file.rotate('z', angle_deg)
+    
+    if addOffset:
+        # Compute offset
+        markers = trc_file.marker_names
+        offset = float('inf')
+        for marker in markers:
+            min_y_pos = np.min(trc_file.marker(marker)[:,1])
+            if min_y_pos < offset:
+                offset = min_y_pos                
+        # Subtract offset
+        trc_file.offset('y', -offset)       
+
+    # Print a new trc file.
+    pathTRCFile_out = os.path.join(
+        sessionDir, 'MarkerData', 
+        trialName + '_{}.trc'.format(suffixOutputFileName))
+    trc_file.write(pathTRCFile_out)
+
+    return pathTRCFile_out

--- a/utilsProcessing.py
+++ b/utilsProcessing.py
@@ -645,8 +645,7 @@ def align_markers_with_ground(sessionDir, trialName,
     if lowpass_cutoff_frequency_for_marker_values > 0:
         mid_m = lowPassFilter(
             time, mid_m, lowpass_cutoff_frequency_for_marker_values)
-    spline = interpolate.InterpolatedUnivariateSpline(
-        time, mid_m[:,1], k=3)
+    spline = interpolate.InterpolatedUnivariateSpline(time, mid_m[:,1], k=3)
     splineD1 = spline.derivative(n=1)
     mid_m_speed = splineD1(time)
 


### PR DESCRIPTION
@suhlrich this PR adds support to correct for a non-perpendicular checkerboard.

Algorithm in brief: 

1. Using vertical speed of mid-hip to identify gait cycles
2. Assuming that vertical position of mid-hip at these times should match
3. Computing angle between X-axis and vector that goes from mid hip coordinated at first identified peak to mid hip coordinated at last identified peak
4. Rotating the data about z-axis
5. Computing vertical offset and correcting for it
6. Generating TRC
7. Running IK

Regarding the example. We can either not push it or either use a different one. It points to a private session now.