### PR TITLE
Force use of x86_64 by cmake as the only available option for now

### DIFF
--- a/UtilsDynamicSimulations/OpenSimAD/utilsOpenSimAD.py
+++ b/UtilsDynamicSimulations/OpenSimAD/utilsOpenSimAD.py
@@ -1775,7 +1775,7 @@ def buildExternalFunction(filename, pathDCAD, CPP_DIR, nInputs,
             cmd_tar = 'tar -xf macOS.tgz -C "{}"'.format(OpenSimAD_DIR)
             os.system(cmd_tar)
             os.remove('macOS.tgz')
-        cmd1 = 'cmake "' + pathBuildExpressionGraph + '" -DTARGET_NAME:STRING="' + filename + '" -DSDK_DIR:PATH="' + OpenSimADOS_DIR + '" -DCPP_DIR:PATH="' + CPP_DIR + '"'
+        cmd1 = 'cmake -DCMAKE_OSX_ARCHITECTURES="x86_64" "' + pathBuildExpressionGraph + '" -DTARGET_NAME:STRING="' + filename + '" -DSDK_DIR:PATH="' + OpenSimADOS_DIR + '" -DCPP_DIR:PATH="' + CPP_DIR + '"'
         cmd2 = "make"
         BIN_DIR = pathBuild
     


### PR DESCRIPTION
This PR forces cmake to use x86_64 when building external function. With that change example_kinetics.py works on apple silicon using x86_64 architecture/stack.